### PR TITLE
Fix leaderboard name capture path

### DIFF
--- a/data/leaderboard/function/lb/add_name_to_storage.mcfunction
+++ b/data/leaderboard/function/lb/add_name_to_storage.mcfunction
@@ -6,11 +6,11 @@
  # Steps:
  #  - summon chest minecart with tag lb_tmp_name
  #  - fill slot 0 with a player_head of @s via loot table
- #  - read Items[0].components.minecraft:profile.name into storage list
+#  - read Items[0].components."minecraft:profile".name into storage list
  #  - tag player as tracked and clean up
  ##
 execute at @s run summon chest_minecart ~ ~ ~ {Tags:["lb_tmp_name"],NoGravity:1b,Silent:1b,Invulnerable:1b}
 loot replace entity @e[type=chest_minecart,tag=lb_tmp_name,limit=1,sort=nearest] container.0 loot leaderboard:entities/player_head
-data modify storage leaderboard:namelist names append from entity @e[type=chest_minecart,tag=lb_tmp_name,limit=1,sort=nearest] Items[0].components.minecraft:profile.name
+data modify storage leaderboard:namelist names append from entity @e[type=chest_minecart,tag=lb_tmp_name,limit=1,sort=nearest] Items[0].components."minecraft:profile".name
 tag @s add lb_tracked
 kill @e[type=chest_minecart,tag=lb_tmp_name,limit=1,sort=nearest]


### PR DESCRIPTION
## Summary
- fix the NBT path used to pull player names from the temporary chest minecart so it works in 1.21.9
- update the inline comment to reflect the quoted minecraft:profile component key

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0aa46c2808323ab8a2c0aac7cce64