### PR TITLE
Fix money leaderboard line rendering

### DIFF
--- a/data/leaderboard/function/lb/add_name_to_storage.mcfunction
+++ b/data/leaderboard/function/lb/add_name_to_storage.mcfunction
@@ -6,11 +6,11 @@
  # Steps:
  #  - summon chest minecart with tag lb_tmp_name
  #  - fill slot 0 with a player_head of @s via loot table
- #  - read Items[0].components.minecraft:profile.name into storage list
+#  - read Items[0].components."minecraft:profile".name into storage list
  #  - tag player as tracked and clean up
  ##
 execute at @s run summon chest_minecart ~ ~ ~ {Tags:["lb_tmp_name"],NoGravity:1b,Silent:1b,Invulnerable:1b}
 loot replace entity @e[type=chest_minecart,tag=lb_tmp_name,limit=1,sort=nearest] container.0 loot leaderboard:entities/player_head
-data modify storage leaderboard:namelist names append from entity @e[type=chest_minecart,tag=lb_tmp_name,limit=1,sort=nearest] Items[0].components.minecraft:profile.name
+data modify storage leaderboard:namelist names append from entity @e[type=chest_minecart,tag=lb_tmp_name,limit=1,sort=nearest] Items[0].components."minecraft:profile".name
 tag @s add lb_tracked
 kill @e[type=chest_minecart,tag=lb_tmp_name,limit=1,sort=nearest]

--- a/data/leaderboard/function/lb/update_line.mcfunction
+++ b/data/leaderboard/function/lb/update_line.mcfunction
@@ -21,7 +21,7 @@ execute if data storage leaderboard:line {rank:7} at @s as @e[type=minecraft:tex
 execute if data storage leaderboard:line {rank:8} at @s as @e[type=minecraft:text_display,tag=leaderboard,tag=!top,limit=1,sort=nearest] run tag @s add slot8
 
 execute if data storage leaderboard:update {score:"money"} as @s run function leaderboard:lb/build_decimal_values with storage leaderboard:line
-$execute if entity @s[nbt={decimal:1}] at @s if entity @e[type=text_display,distance=..0.001,nbt={transformation:{translation:[0f,$(sep)f,0f],scale:[1f,1f,1f]}}] run data modify entity @e[type=text_display,distance=..0.001,limit=1,sort=nearest] text set value [{"text":"$(rank). "},{"text":"$(name)","bold":$(bold_name)}," "," : "," ",{"text":"$(value_int).$(value_frac)","color":"red"}]
+$execute if entity @s[nbt={decimal:1}] at @s if entity @e[type=minecraft:text_display,tag=leaderboard,tag=!top,tag=slot$(rank),distance=..32] run data modify entity @e[type=minecraft:text_display,tag=leaderboard,tag=!top,tag=slot$(rank),limit=1,sort=nearest] text set value [{"text":"$(rank). "},{"text":"$(name)","bold":$(bold_name)}," ",{"text":": "},{"text":"$(value_int).$(value_frac_tens)$(value_frac_ones)","color":"red"}]
 
  # update_line.mcfunction
  # 
@@ -58,7 +58,7 @@ $execute at @s if entity @e[type=text_display,distance=..0.001,nbt={transformati
 
 # === Tag-per-slot ensure + render (robust) ===
 # Ensure a unique line entity exists for this rank using tag slot$(rank)
-$execute if data storage leaderboard:update {score:"money"} at @s unless entity @e[type=minecraft:text_display,tag=leaderboard,tag=!top,tag=slot$(rank),distance=..32] run summon minecraft:text_display ~ ~ ~ {Tags:["leaderboard","slot$(rank)"],billboard:"vertical",alignment:"left",line_width:2000,see_through:0,transformation:{translation:[0f,$(sep)f,0f],scale:[1f,1f,1f]}}
+$execute if data storage leaderboard:update {score:"money"} at @s unless entity @e[type=minecraft:text_display,tag=leaderboard,tag=!top,tag=slot$(rank),distance=..32] run summon minecraft:text_display ~ ~ ~ {Tags:["leaderboard","slot$(rank)","$(lines)"],data:{score:$(score)},billboard:"vertical",alignment:"left",line_width:2000,see_through:0,transformation:{translation:[0f,-$(sep)f,0f],scale:[1f,1f,1f]}}
 # Recompute decimals every update for Money
 execute if data storage leaderboard:update {score:"money"} as @s run function leaderboard:lb/build_decimal_values with storage leaderboard:line
 # Update that slot's text


### PR DESCRIPTION
## Summary
- ensure decimal leaderboards update their lines using slot tags and explicit two-digit cents
- spawn fallback money line displays with the same tags and score metadata the rest of the system expects

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e0aa46c2808323ab8a2c0aac7cce64