### PR TITLE
Format leaderboard entries as currency amounts

### DIFF
--- a/data/leaderboard/function/commands/reset.mcfunction
+++ b/data/leaderboard/function/commands/reset.mcfunction
@@ -10,8 +10,16 @@ scoreboard players set #const.1 leaderboard 1
 scoreboard players set #const.2 leaderboard 2
 scoreboard players set #const.3 leaderboard 3
 scoreboard players set #const.5 leaderboard 5
+scoreboard players set #const.10 leaderboard 10
 scoreboard players set #const.20 leaderboard 20
 scoreboard players set #const.60 leaderboard 60
+scoreboard players set #const.100 leaderboard 100
+
+scoreboard players set #int.money_total leaderboard 0
+scoreboard players set #int.money_dollars leaderboard 0
+scoreboard players set #int.money_cents leaderboard 0
+scoreboard players set #int.money_cents_tens leaderboard 0
+scoreboard players set #int.money_cents_ones leaderboard 0
 
 # init time_mode storage
 data modify storage leaderboard:line value_0 set value 0

--- a/data/leaderboard/function/lb/run_uninstall.mcfunction
+++ b/data/leaderboard/function/lb/run_uninstall.mcfunction
@@ -29,6 +29,9 @@ data remove storage leaderboard:line bright
 data remove storage leaderboard:line color
 data remove storage leaderboard:line bold_name
 data remove storage leaderboard:line close_background
+data remove storage leaderboard:line money_dollars
+data remove storage leaderboard:line money_cents_tens
+data remove storage leaderboard:line money_cents_ones
 
 
 data remove storage leaderboard:init_edit reverse_order

--- a/data/leaderboard/function/lb/update_line.mcfunction
+++ b/data/leaderboard/function/lb/update_line.mcfunction
@@ -4,7 +4,7 @@
  #
  # Created by DJT3.
 ##
-$execute if entity @s[nbt={data:{time_mode:0}}] at @s if entity @e[type=text_display,distance=..0.001,nbt={transformation:{translation:[0f,-$(sep)f,0f]},data:{score:$(score)}},tag=!top,tag=$(lines)] run data modify entity @e[type=minecraft:text_display,tag=!top,limit=1,sort=nearest,tag=$(lines)] text set value {"text":"","extra":[{"text":"#$(rank)","color":"$(color)"}," ",{"text":"$(name)","bold":$(bold_name)}," "," : "," ",{"text":"$(value)","color":"red"}]}
+$execute if entity @s[nbt={data:{time_mode:0}}] at @s if entity @e[type=text_display,distance=..0.001,nbt={transformation:{translation:[0f,-$(sep)f,0f]},data:{score:$(score)}},tag=!top,tag=$(lines)] run data modify entity @e[type=minecraft:text_display,tag=!top,limit=1,sort=nearest,tag=$(lines)] text set value {"text":"","extra":[{"text":"#$(rank)","color":"$(color)"}," ",{"text":"$(name)","bold":$(bold_name)}," "," : "," ",{"text":"$","color":"red"},{"text":"$(money_dollars)","color":"red"},{"text":".","color":"red"},{"text":"$(money_cents_tens)$(money_cents_ones)","color":"red"}]}
 
 #Time
 # XH Xm Xs XXms

--- a/data/leaderboard/function/lb/update_line_init.mcfunction
+++ b/data/leaderboard/function/lb/update_line_init.mcfunction
@@ -15,5 +15,22 @@ data modify storage leaderboard:line close_background set value 1
 $execute as @s at @s if entity @s[nbt={data:{always_show_closest_player:1}}] if entity @p[distance=..10,name='$(name)'] run data modify storage leaderboard:line bold_name set value "true"
 $execute as @s at @s if entity @s[nbt={data:{always_show_closest_player:1}}] if entity @p[distance=..10,name='$(name)'] run data modify storage leaderboard:line close_background set value 0
 
+$execute store result score #int.money_total leaderboard run scoreboard players get $(name) $(score)
+scoreboard players set #int.money_dollars leaderboard 0
+scoreboard players set #int.money_cents leaderboard 0
+scoreboard players set #int.money_cents_tens leaderboard 0
+scoreboard players set #int.money_cents_ones leaderboard 0
+scoreboard players operation #int.money_dollars leaderboard = #int.money_total leaderboard
+scoreboard players operation #int.money_dollars leaderboard /= #const.100 leaderboard
+scoreboard players operation #int.money_cents leaderboard = #int.money_total leaderboard
+scoreboard players operation #int.money_cents leaderboard %= #const.100 leaderboard
+scoreboard players operation #int.money_cents_tens leaderboard = #int.money_cents leaderboard
+scoreboard players operation #int.money_cents_tens leaderboard /= #const.10 leaderboard
+scoreboard players operation #int.money_cents_ones leaderboard = #int.money_cents leaderboard
+scoreboard players operation #int.money_cents_ones leaderboard %= #const.10 leaderboard
+execute store result storage leaderboard:line money_dollars int 1 run scoreboard players get #int.money_dollars leaderboard
+execute store result storage leaderboard:line money_cents_tens int 1 run scoreboard players get #int.money_cents_tens leaderboard
+execute store result storage leaderboard:line money_cents_ones int 1 run scoreboard players get #int.money_cents_ones leaderboard
+
 $execute store result storage leaderboard:line value int 1 run scoreboard players get $(name) $(score)
 execute as @s run function leaderboard:lb/update_line with storage leaderboard:line


### PR DESCRIPTION
## Summary
- convert scoreboard money values into whole dollars and cents for each leaderboard line
- display leaderboard rows as $X.XX amounts and seed new constants needed for division
- clear stored currency metadata when the datapack is uninstalled

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e0c77b57e8832390c9ddf720cc1d3e